### PR TITLE
Add the [FMBbCodeBundle] as a dependency instead of the [php-decoda] again

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Using the vendors script
 
 Add the following lines in your ``deps`` file::
 
-    [php-decoda]
-    git=http://github.com/milesj/php-decoda.git
+    [FMBbCodeBundle]
+    git=http://github.com/helios-ag/FMBbCodeBundle.git
 
 Run the vendors script::
 


### PR DESCRIPTION
Probably just a typo, but the FMBBCodeBundle should be added here instead of the php-decoda repo again.
