### PR TITLE
Case differences in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "mjohnson/decoda": "3.*"
     },
     "autoload": {
-        "psr-0": { "FM\\BBCodeBundle": "" }
+        "psr-0": { "FM\\BbcodeBundle": "" }
     },
-    "target-dir": "FM/BbCodeBundle"
+    "target-dir": "FM/BbcodeBundle"
 }


### PR DESCRIPTION
Glad to see that you've updated your bundle to work nicely with composer.json, but there's a slight issue:

You use two different capitalisations in your composer.json, and both of them are different to what a user gets when they clone your git repo - this causes issues on case-sensitive systems where the autoloader won't recognize the bundle.

This pull request fixes that
