### PR TITLE
Add standard template locating

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ messages: node. File should be json formatted.
 ```yaml
 fm_bbcode:
     config:
-      messages: @BundleName/Resources/config/messages.json
+      messages: @SomeBundle/Resources/config/messages.json
 ```
 
 ### Adding own templates
@@ -157,6 +157,6 @@ Your own templates can be defined at templates node, the example below shows how
     fm_bbcode:
         config:
           templates:
-            - path: @BundleName/Resources/views/templates
+            - path: @SomeBundle/Resources/views/templates
 ```
 Template examples can be found inside decoda library

--- a/Templating/BbcodeExtension.php
+++ b/Templating/BbcodeExtension.php
@@ -42,7 +42,7 @@ class BbcodeExtension extends \Twig_Extension
         }
         foreach ($extraTemplatePaths as $extraPath) {
             $path = $extraPath['path'];
-            $path = $this->container->get("kernel")->locateResource($path);
+            $path = $this->container->get('file_locator')->locate($path);
             DecodaManager::addTemplatePath($path);
         }
 
@@ -76,13 +76,10 @@ class BbcodeExtension extends \Twig_Extension
 
         $messages = $this->container->getParameter('fm_bbcode.config.messages');
         
-        if(!empty($messages))
-        {
-            $messages = $this->container->get("kernel")->locateResource($messages);
+        if (!empty($messages)) {
+            $messages = $this->container->get('file_locator')->locate($messages);
             $messages = json_decode(\file_get_contents($messages), true);
-        }
-        else
-        {
+        } else {
             $messages = array();
         }
 

--- a/Templating/Helper/BbcodeHelper.php
+++ b/Templating/Helper/BbcodeHelper.php
@@ -43,7 +43,7 @@ class BbcodeHelper extends Helper {
         }
         foreach ($extra_templatePaths as $extra_path) {
             $path = $extra_path['path'];
-            $path = $this->container->get("kernel")->locateResource($path);
+            $path = $this->container->get('file_locator')->locate($path);
             DecodaManager::addTmplatePath($path);
         }
     }
@@ -61,13 +61,10 @@ class BbcodeHelper extends Helper {
 
         $messages = $this->container->getParameter('fm_bbcode.config.messages');
 
-        if(!empty($messages))
-        {
-            $messages = $this->container->get("kernel")->locateResource($messages);
+        if (!empty($messages)) {
+            $messages = $this->container->get("file_locator")->locate($messages);
             $messages = json_decode(\file_get_contents($messages), true);
-        }
-        else
-        {
+        } else {
             $message = array();
         }
 

--- a/Tests/FunctionalTestBundle/Resources/config/config.yml
+++ b/Tests/FunctionalTestBundle/Resources/config/config.yml
@@ -1,8 +1,8 @@
 fm_bbcode:
   config:
     templates:
-      - path: "@FMBbcodeBundle/Tests/FunctionalTestBundle/Resources/views/templates"
-    messages: "@FMBbcodeBundle/Tests/FunctionalTestBundle/Resources/config/messages.json"
+      - path: "@FunctionalTestBundle/Resources/views/templates"
+    messages: "%kernel.root_dir%/FunctionalTestBundle/Resources/config/messages.json"
   filter_sets:
     default_filter:
       locale: ru


### PR DESCRIPTION
<table>
  <tr>
    <th>Q</th><th>A</th>
  </tr>
  <tr>
    <td>Bug fix?</td><td>no</td>
  </tr>
  <tr>
    <td>New feature?</td><td>no</td>
  </tr>
  <tr>
    <td>BC breaks?</td><td>no</td>
  </tr>
  <tr>
    <td>Tests pass?</td><td>not yet</td>
  </tr>
  <tr>
    <td>License?</td><td>MIT</td>
  </tr>
</table>


Usage of standard file location also work now (e.g. `path/to/messages.json`).
