### PR TITLE
Add ability to register hooks and filters as a service

### DIFF
--- a/Decoda/Decoda.php
+++ b/Decoda/Decoda.php
@@ -2,6 +2,8 @@
 
 namespace FM\BbcodeBundle\Decoda;
 
+use Decoda\Hook;
+use Decoda\Filter;
 use Decoda\Decoda as BaseDecoda;
 use \DomainException;
 
@@ -15,6 +17,7 @@ class Decoda extends BaseDecoda
      * @var string
      */
     protected $defaultLocale;
+
 
     /**
      * @param string $string    The string to parse
@@ -185,5 +188,147 @@ class Decoda extends BaseDecoda
         }
 
         return parent::addPath($path);
+    }
+
+
+    /**
+     * Add additional filters.
+     *
+     * @see \Decoda\Decoda::addFilter()
+     *
+     * @param Filter $filter
+     * @param string $id
+     *
+     * @return Decoda
+     */
+    public function addFilter(Filter $filter, $id = null)
+    {
+        $filter->setParser($this);
+
+        if (null === $id) {
+            // this is to keep method signature
+            $id = explode('\\', get_class($filter));
+            $id = str_replace('Filter', '', end($id));
+        }
+
+        $id = strtolower($id);
+
+        $tags = $filter->tags();
+
+        $this->_filters[$id] = $filter;
+
+        $this->_tags = $tags + $this->_tags;
+
+        foreach ($tags as $tag => $options) {
+            $this->_filterMap[$tag] = $id;
+        }
+
+        $filter->setupHooks($this);
+
+        return $this;
+    }
+
+    /**
+     * Check if a filter exists.
+     *
+     * @see \Decoda\Decoda::hasFilter()
+     *
+     * @param string $id
+     * @return boolean
+     */
+    public function hasFilter($id)
+    {
+        return parent::hasFilter(strtolower($id));
+    }
+
+    /**
+     * Return a specific filter based on filter id.
+     *
+     * @see \Decoda\Decoda::getFilter()
+     *
+     * @param string $id
+     * @throws InvalidArgumentException
+     * @return \Decoda\Filter[]
+     */
+    public function getFilter($id)
+    {
+        return parent::getFilter(strtolower($id));
+    }
+
+    /**
+     * Remove filter(s).
+     *
+     * @param string|array $filters
+     * @return \Decoda\Decoda
+     */
+    public function removeFilter($ids)
+    {
+        return parent::removeFilter(array_map('strtolower', (array) $ids));
+    }
+
+    /**
+     * Add hooks that are triggered at specific events.
+     *
+     * @see \Decoda\Decoda::addHook()
+     *
+     * @param Hook   $hook
+     * @param string $id
+     *
+     * @return Decoda
+     */
+    public function addHook(Hook $hook, $id = null)
+    {
+        $hook->setParser($this);
+
+        if (null === $id) {
+            // this is to keep method signature
+            $id = explode('\\', get_class($hook));
+            $id = str_replace('Filter', '', end($id));
+        }
+
+        $this->_hooks[strtolower($id)] = $hook;
+
+        $hook->setupFilters($this);
+
+        return $this;
+    }
+
+
+    /**
+     * Check if a hook exists.
+     *
+     * @see \Decoda\Decoda::hasHook()
+     *
+     * @param string $id
+     * @return boolean
+     */
+    public function hasHook($id)
+    {
+        return parent::hasHook(strtolower($id));
+    }
+
+    /**
+     * Return a specific hook based on hook id.
+     *
+     * @see \Decoda\Decoda::getHook()
+     *
+     * @param string $id
+     * @throws InvalidArgumentException
+     * @return \Decoda\Hook[]
+     */
+    public function getHook($id)
+    {
+        return parent::getHook(strtolower($id));
+    }
+
+    /**
+     * Remove hook(s).
+     *
+     * @param string|array $hooks
+     * @return \Decoda\Decoda
+     */
+    public function removeHook($ids)
+    {
+        return parent::removeHook(array_map('strtolower', (array) $ids));
     }
 }

--- a/DependencyInjection/Compiler/RegisterFiltersPass.php
+++ b/DependencyInjection/Compiler/RegisterFiltersPass.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace FM\BbcodeBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class RegisterFiltersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('fm_bbcode.decoda_manager')) {
+            return;
+        }
+
+        $filters = array();
+        foreach ($container->findTaggedServiceIds('fm_bbcode.decoda.filter') as $id => $attributes) {
+            $name = isset($attributes[0]['id']) ? $attributes[0]['id'] : $id;
+            $name = strtolower($name);
+            if (isset($filters[$name])) {
+                throw new \InvalidArgumentException(sprintf(
+                    'The filter identifier "%s" must be uniq.',
+                    $name
+                ));
+            }
+            $filters[$name] = new Reference($id);
+        }
+
+        $container->getDefinition('fm_bbcode.decoda_manager')->addMethodCall('addFilters', array($filters));
+    }
+}

--- a/DependencyInjection/Compiler/RegisterHooksPass.php
+++ b/DependencyInjection/Compiler/RegisterHooksPass.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace FM\BbcodeBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class RegisterHooksPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('fm_bbcode.decoda_manager')) {
+            return;
+        }
+
+        $hooks = array();
+        foreach ($container->findTaggedServiceIds('fm_bbcode.decoda.hook') as $id => $attributes) {
+            $name = isset($attributes[0]['id']) ? $attributes[0]['id'] : $id;
+            $name = strtolower($name);
+            if (isset($filters[$name]) || $name == null) {
+                throw new \InvalidArgumentException(sprintf(
+                    'The hook identifier "%s" must be uniq.',
+                    $name
+                ));
+            }
+            $hooks[$name] = new Reference($id);
+        }
+
+        $container->getDefinition('fm_bbcode.decoda_manager')->addMethodCall('addHooks', array($hooks));
+    }
+}

--- a/DependencyInjection/FMBbcodeExtension.php
+++ b/DependencyInjection/FMBbcodeExtension.php
@@ -26,8 +26,19 @@ class FMBbcodeExtension extends Extension
         $config = $this->processConfiguration(new Configuration(), $configs);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('bbcode.xml');
-        $hooks = isset($config['config']['hooks']) ? $config['config']['hooks'] : array();
-        $filters = isset($config['config']['filters']) ? $config['config']['filters'] : array();
+
+        $hooksConfig = isset($config['config']['hooks']) ? $config['config']['hooks'] : array();
+        $hooks = array();
+        foreach ($hooksConfig as $hook) {
+            $hooks[$hook['classname']] = $hook['class'];
+        }
+
+        $filtersConfig = isset($config['config']['filters']) ? $config['config']['filters'] : array();
+        $filters = array();
+        foreach ($filtersConfig as $filter) {
+            $filters[$filter['classname']] = $filter['class'];
+        }
+
         $container->setParameter('fm_bbcode.filter_sets', $config['filter_sets']);
         $container->setParameter('fm_bbcode.config.filters', $filters);
         $container->setParameter('fm_bbcode.config.hooks', $hooks);

--- a/FMBbcodeBundle.php
+++ b/FMBbcodeBundle.php
@@ -2,8 +2,22 @@
 
 namespace FM\BbcodeBundle;
 
+use FM\BbcodeBundle\DependencyInjection\Compiler\RegisterHooksPass;
+use FM\BbcodeBundle\DependencyInjection\Compiler\RegisterFiltersPass;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class FMBbcodeBundle extends Bundle
 {
+    /**
+     * @see Bundle::build()
+     *
+     * @param ContainerBuilder $container
+     */
+    public function build(ContainerBuilder $container)
+    {
+         $container->addCompilerPass(new RegisterFiltersPass());
+         $container->addCompilerPass(new RegisterHooksPass());
+    }
 }

--- a/Templating/BbcodeExtension.php
+++ b/Templating/BbcodeExtension.php
@@ -43,34 +43,40 @@ class BbcodeExtension extends \Twig_Extension
 
     /**
      * @param $value
-     * @param $filter
+     * @param $filterSet
+     *
      * @return string
-     * @throws \Twig_Error_Runtime
+     *
      * @return \FM\BbcodeBundle\Decoda\Decoda
+     *
+     * @throws \Twig_Error_Runtime
      */
-    public function filter($value, $filter)
+    public function filter($value, $filterSet = DecodaManager::DECODA_DEFAULT)
     {
         if (!is_string($value)) {
             throw new \Twig_Error_Runtime('The filter can be applied to strings only.');
         }
 
-        return $this->decodaManager->getDecoda($value, $filter)->parse();
+        return $this->decodaManager->get($value, $filterSet)->parse();
     }
 
     /**
-     *
      * Strip tags
+     *
      * @param $value
+     * @param $filterSet
+     *
      * @return string
+     *
      * @throws \Twig_Error_Runtime
      */
-    public function clean($value)
+    public function clean($value, $filterSet = DecodaManager::DECODA_DEFAULT)
     {
         if (!is_string($value)) {
             throw new \Twig_Error_Runtime('The filter can be applied to strings only.');
         }
 
-        return $this->decodaManager->getDecoda($value)->strip(true);
+        return $this->decodaManager->get($value, $filterSet)->strip(true);
     }
 
     /**

--- a/Templating/Helper/BbcodeHelper.php
+++ b/Templating/Helper/BbcodeHelper.php
@@ -29,37 +29,38 @@ class BbcodeHelper extends Helper
 
     /**
      * @param $value
-     * @param $filter
+     * @param $filterSet
      *
      * @return string
      *
      * @throws \Twig_Error_Runtime
      */
-    public function filter($value, $filter)
+    public function filter($value, $filterSet = DecodaManager::DECODA_DEFAULT)
     {
         if (!is_string($value)) {
             throw new \Twig_Error_Runtime('The filter can be applied to strings only.');
         }
 
-        return $this->decodaManager->getDecoda($value, $filter)->parse();
+        return $this->decodaManager->get($value, $filterSet)->parse();
     }
 
     /**
-     *
      * Strip tags
+     *
      * @param $value
+     * @param $filterSet
      *
      * @return string
      *
      * @throws \Twig_Error_Runtime
      */
-    public function clean($value)
+    public function clean($value, $filterSet = DecodaManager::DECODA_DEFAULT)
     {
         if (!is_string($value)) {
             throw new \Twig_Error_Runtime('The filter can be applied to strings only.');
         }
 
-        return $this->decodaManager->getDecoda($value)->strip(true);
+        return $this->decodaManager->get($value, $filterSet)->strip(true);
     }
 
     public function getName()

--- a/Tests/FunctionalTestBundle/Resources/config/config.yml
+++ b/Tests/FunctionalTestBundle/Resources/config/config.yml
@@ -1,8 +1,26 @@
+parameters:
+  fm_bbcode.filter.bar.class: Decoda\Filter\DefaultFilter
+  fm_bbcode.hook.bar.class: Decoda\Hook\ClickableHook
+
+services:
+  fm_bbcode.filter.bar:
+    class: %fm_bbcode.filter.bar.class%
+    tags:
+         - { name: fm_bbcode.decoda.filter, id: bar }
+  fm_bbcode.hook.bar:
+    class: %fm_bbcode.hook.bar.class%
+    tags:
+         - { name: fm_bbcode.decoda.hook, id: bar }
+
 fm_bbcode:
   config:
     templates:
       - path: "@FunctionalTestBundle/Resources/views/templates"
     messages: "%kernel.root_dir%/FunctionalTestBundle/Resources/config/messages.json"
+    filters:
+      - { classname: foo, class: %fm_bbcode.filter.bar.class% }
+    hooks:
+      - { classname: foo, class: %fm_bbcode.hook.bar.class% }
   filter_sets:
     default_filter:
       locale: ru
@@ -29,6 +47,18 @@ fm_bbcode:
       xhtml: true
       filters: [ url ]
       strict: false
+    foo_filter:
+      xhtml: true
+      filters: [ foo ]
+    bar_filter:
+      xhtml: true
+      filters: [ bar ]
+    foo_hook:
+      filters: [ url, email ]
+      hooks: [ foo ]
+    bar_hook:
+      filters: [ url, email ]
+      hooks: [ bar ]
 framework:
   form: ~
   router:

--- a/Tests/FunctionalTestBundle/Resources/views/filters/bar_filter.html.twig
+++ b/Tests/FunctionalTestBundle/Resources/views/filters/bar_filter.html.twig
@@ -1,0 +1,1 @@
+{{value|bbcode_filter('bar_filter')}}

--- a/Tests/FunctionalTestBundle/Resources/views/filters/bar_hook.html.twig
+++ b/Tests/FunctionalTestBundle/Resources/views/filters/bar_hook.html.twig
@@ -1,0 +1,1 @@
+{{value|bbcode_filter('bar_hook')}}

--- a/Tests/FunctionalTestBundle/Resources/views/filters/default_filter_set.html.twig
+++ b/Tests/FunctionalTestBundle/Resources/views/filters/default_filter_set.html.twig
@@ -1,0 +1,1 @@
+{{value|bbcode_filter}}

--- a/Tests/FunctionalTestBundle/Resources/views/filters/foo_filter.html.twig
+++ b/Tests/FunctionalTestBundle/Resources/views/filters/foo_filter.html.twig
@@ -1,0 +1,1 @@
+{{value|bbcode_filter('foo_filter')}}

--- a/Tests/FunctionalTestBundle/Resources/views/filters/foo_hook.html.twig
+++ b/Tests/FunctionalTestBundle/Resources/views/filters/foo_hook.html.twig
@@ -1,0 +1,1 @@
+{{value|bbcode_filter('foo_hook')}}

--- a/Tests/Templating/BbcodeExtensionTest.php
+++ b/Tests/Templating/BbcodeExtensionTest.php
@@ -105,4 +105,83 @@ class BbcodeExtensionTest extends TwigBasedTestCase
             array('[url=http://example.com]Example[/url]','<a href="http://example.com">Example</a>')
         );
     }
+
+    /**
+     * @dataProvider dataDefaultTags
+     */
+    public function testFooFilter($value, $expected)
+    {
+        $this->assertSame($expected,
+            $this->getTwig()->render('FunctionalTestBundle:filters:foo_filter.html.twig', array(
+                'value' => $value,
+            )));
+    }
+
+    /**
+     * @dataProvider dataDefaultTags
+     */
+    public function testBarFilter($value, $expected)
+    {
+        $this->assertSame($expected,
+            $this->getTwig()->render('FunctionalTestBundle:filters:bar_filter.html.twig', array(
+                'value' => $value,
+            )));
+    }
+
+    /**
+     * @dataProvider dataClickableHook
+     */
+    public function testFooHook($value, $expected)
+    {
+        $this->assertSame($expected,
+            $this->getTwig()->render('FunctionalTestBundle:filters:foo_hook.html.twig', array(
+                'value' => $value,
+            )));
+    }
+
+
+    /**
+     * @dataProvider dataClickableHook
+     */
+    public function testBarHook($value, $expected)
+    {
+        $this->assertSame($expected,
+            $this->getTwig()->render('FunctionalTestBundle:filters:bar_hook.html.twig', array(
+                'value' => $value,
+            )));
+    }
+
+    public function dataClickableHook()
+    {
+        return array(
+            array('http://domain.com', '<a href="http://domain.com">http://domain.com</a>'),
+        );
+    }
+
+    /**
+     * @dataProvider dataDefaultFilterSet
+     */
+    public function testDefaultFilterSet($value, $expected)
+    {
+        $this->assertSame($expected,
+            $this->getTwig()->render('FunctionalTestBundle:filters:default_filter_set.html.twig', array(
+                'value' => $value,
+            )));
+    }
+
+    public function dataDefaultFilterSet()
+    {
+        return array(
+            array('[b]Bold[/b]', "<b>Bold</b>"),
+            array('[i]Italic[/i]', "<i>Italic</i>"),
+            array('[u]Underline[/u]', "<u>Underline</u>"),
+            array('[s]strikeout[/s]', "<del>strikeout</del>"),
+            array('[sub]subscript[/sub]', "<sub>subscript</sub>"),
+            array('[sup]superscript[/sup]', "<sup>superscript</sup>"),
+            array('[abbr="Object relational mapper"]ORM[/abbr]', '<abbr title="Object relational mapper">ORM</abbr>'),
+            array('[url]http://example.org[/url]','<a href="http://example.org">http://example.org</a>'),
+            array('[url="http://example.com"]Example[/url]','<a href="http://example.com">Example</a>'),
+            array('[email]email@domain.com[/email]', '<a href="mailto:&#101;&#109;&#97;&#105;&#108;&#64;&#100;&#111;&#109;&#97;&#105;&#110;&#46;&#99;&#111;&#109;">&#101;&#109;&#97;&#105;&#108;&#64;&#100;&#111;&#109;&#97;&#105;&#110;&#46;&#99;&#111;&#109;</a>'),
+        );
+    }
 }


### PR DESCRIPTION
```
services:
  fm_bbcode.filter.bar:
    class: %fm_bbcode.filter.bar.class%
    tags:
      - { name: fm_bbcode.decoda.filter, id: my_filter_id }

  fm_bbcode.hook.bar:
    class: %fm_bbcode.hook.bar.class%
    tags:
      - { name: fm_bbcode.decoda.hook, id: my_hook_id }
```

<table>
  <tr>
    <th>Q</th><th>A</th>
  </tr>
  <tr>
    <td>Bug fix?</td><td>no</td>
  </tr>
  <tr>
    <td>New feature?</td><td>yes</td>
  </tr>
  <tr>
    <td>BC breaks?</td><td>no</td>
  </tr>
  <tr>
    <td>Tests pass?</td><td>yes</td>
  </tr>
  <tr>
    <td>License?</td><td>MIT</td>
  </tr>
</table>
