### PR TITLE
Fixes the 'unable to open json file' error

### DIFF
--- a/Decoda/Decoda.php
+++ b/Decoda/Decoda.php
@@ -46,7 +46,7 @@ class Decoda extends BaseDecoda
     public function setMessages($messages = array())
     {
         if (empty($messages)) {
-            $this->_messages = json_decode(\file_get_contents('../Resources/config/messages.json'), true);
+            $this->_messages = json_decode(\file_get_contents(__DIR__ . '/../Resources/config/messages.json'), true);
         } else {
             $this->_messages = $messages;
         }


### PR DESCRIPTION
Symfony fails to open the `messages.json` file. I've added the `__DIR__` recognition to pick up the current working directory for the `Decoda.php` file
