### PR TITLE
Add missing return on EmoticonHook::setParser method

### DIFF
--- a/Decoda/Hook/EmoticonHook.php
+++ b/Decoda/Hook/EmoticonHook.php
@@ -262,12 +262,16 @@ class EmoticonHook extends BaseEmoticonHook implements CacheWarmerInterface
      * @see \Decoda\Hook\EmoticonHook::setParser()
      *
      * @param Decoda $parser
+     *
+     * @return EmoticonHook
      */
     public function setParser(Decoda $parser)
     {
         parent::setParser($parser);
 
         $this->_emoticons = $this->getMatcher()->getEmoticons();
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
<table>
  <tr>
    <th>Q</th><th>A</th>
  </tr>
  <tr>
    <td>Bug fix?</td><td>yes</td>
  </tr>
  <tr>
    <td>New feature?</td><td>no</td>
  </tr>
  <tr>
    <td>BC breaks?</td><td>no</td>
  </tr>
  <tr>
    <td>Tests pass?</td><td>yes</td>
  </tr>
  <tr>
    <td>License?</td><td>MIT</td>
  </tr>
</table>
