### PR TITLE
[5.x] Fix use statement on EmoticonHook (closes #63)

### DIFF
--- a/Decoda/Hook/EmoticonHook.php
+++ b/Decoda/Hook/EmoticonHook.php
@@ -12,7 +12,7 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\ConfigCache;
 
 use Decoda\Decoda;
-use Decoda\Hook\EmoticonHook as BaseEmoticonHook;
+use \Decoda\Hook\EmoticonHook as BaseEmoticonHook;
 
 use FM\BbcodeBundle\Emoticon\Emoticon;
 use FM\BbcodeBundle\Emoticon\EmoticonCollection;


### PR DESCRIPTION
<table>
  <tr>
    <th>Q</th><th>A</th>
  </tr>
  <tr>
    <td>Bug fix?</td><td>yes</td>
  </tr>
  <tr>
    <td>New feature?</td><td>no</td>
  </tr>
  <tr>
    <td>BC breaks?</td><td>no</td>
  </tr>
  <tr>
    <td>Tests pass?</td><td>yes</td>
  </tr>
  <tr>
    <td>License?</td><td>MIT</td>
  </tr>
</table>


This PR try to fix #63
