### PR TITLE
Fix line breaks configuration feature (nl2br)

### DIFF
--- a/Decoda/DecodaManager.php
+++ b/Decoda/DecodaManager.php
@@ -450,7 +450,7 @@ class DecodaManager
         $decoda->setXhtml($options['xhtml']);
         $decoda->setStrict($options['strict']);
         $decoda->setEscaping($options['escaping']);
-        $decoda->convertLineBreaks($options['line_breaks']);
+        $decoda->setConfig(array('lineBreaks' => $options['line_breaks']));
 
         foreach ($options['filters'] as $id) {
             $decoda->addFilter($this->getFilter($id), $id);


### PR DESCRIPTION
| Q | A |
| --: | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #83 |
| License | MIT |

Line breaks Decoda configuration was [added since version 6.2.0](https://github.com/milesj/Decoda/compare/6.1.0...6.2.0). To keep back compatibility it use `Decoda::setConfig()`.
