### PR TITLE
Fix composer script handler dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "symfony/process": "~2.0",
         "symfony/templating": "~2.0",
         "symfony/yaml": "~2.0",
-        "sensio/distribution-bundle": "~2.0"
+        "sensio/distribution-bundle": "~2.1"
     },
     "require-dev": {
         "symfony/symfony": "~2.1"


### PR DESCRIPTION
| Q | A |
| --: | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

The class `Sensio\Bundle\DistributionBundle\Composer\ScriptHandler` was added since v2.1.0 [@source](https://github.com/sensiolabs/SensioDistributionBundle/commit/aa1cf4afe0eabd01190dc4d239a57a30f851eb62)
