### PR TITLE
strict filter parameter has been added

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Define BBCode filter in your config.yml:
     fm_bbcode:
       filter_sets:
         my_default_filter:
+          strict: false # if you want to parse attr values without quotes
           locale: ru
           xhtml: true
           filters: [ default ]


### PR DESCRIPTION
Some of WYSIWIG editors using bbcodes with attributes without quotes. For example [url=http://mysite.com]my site[/url]. And this parameter is very useful and it shall be mentioned in configuration examples.
