### PR TITLE
Fixed the emoticon addition when it already exists

### DIFF
--- a/Emoticon/EmoticonCollection.php
+++ b/Emoticon/EmoticonCollection.php
@@ -66,14 +66,11 @@ class EmoticonCollection implements \IteratorAggregate, \Countable
      */
     public function add($name, Emoticon $emoticon)
     {
-        if ($this->has($name)) {
-            $this->remove($name);
-        }
+        unset($this->emoticons[$name]);
 
         foreach ($emoticon as $smiley) {
-            if (isset($this->smileyMap[$smiley])) {
-                throw new \InvalidArgumentException(sprintf('The smiley "%s" already exists.', $smiley));
-            }
+            unset($this->smileyMap[$smiley]);
+
             $this->smileyMap[$smiley] = $emoticon;
         }
 

--- a/Tests/Emoticon/EmoticonCollectionTest.php
+++ b/Tests/Emoticon/EmoticonCollectionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace FM\BbcodeBundle\Tests\Emoticon;
+
+use FM\BbcodeBundle\Emoticon\Emoticon;
+use FM\BbcodeBundle\Emoticon\EmoticonCollection;
+
+/**
+ * @author Alexandre Quercia <alquerci@email.com>
+ */
+class EmoticonCollectionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAddOverriddenEmoticon()
+    {
+        $collection = new EmoticonCollection();
+        $emoticon = new Emoticon();
+        $emoticon->setSmilies(array(':foo:'));
+        $emoticon1 = new Emoticon();
+        $emoticon1->setSmilies(array(':bar:'));
+        $emoticon2 = new Emoticon();
+        $emoticon2->setSmilies(array(':foofoo:'));
+
+        $collection->add('foo', $emoticon);
+        $collection->add('bar', $emoticon1);
+        $collection->add('foo', $emoticon2);
+
+        $this->assertSame(array(':foo:', ':bar:', ':foofoo:'), $collection->getSmilies());
+        $this->assertSame(array('bar' => $emoticon1, 'foo' => $emoticon2), $collection->all());
+        $this->assertSame($emoticon1, $collection->getEmoticonBySmiley(':bar:'));
+        $this->assertSame($emoticon, $collection->getEmoticonBySmiley(':foo:'));
+        $this->assertSame($emoticon2, $collection->getEmoticonBySmiley(':foofoo:'));
+    }
+
+    public function testAddOverriddenSmiley()
+    {
+        $collection = new EmoticonCollection();
+        $emoticon = new Emoticon();
+        $emoticon->setSmilies(array(':foo:', ':foofoo:'));
+        $emoticon1 = new Emoticon();
+        $emoticon1->setSmilies(array(':foo:', ':bar:'));
+
+        $collection->add('foo', $emoticon);
+        $collection->add('bar', $emoticon1);
+
+        $this->assertSame(array(':foofoo:', ':foo:', ':bar:'), $collection->getSmilies());
+        $this->assertSame($emoticon, $collection->getEmoticonBySmiley(':foofoo:'));
+        $this->assertSame($emoticon1, $collection->getEmoticonBySmiley(':foo:'));
+        $this->assertSame($emoticon1, $collection->getEmoticonBySmiley(':bar:'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Related tickets | #89
| License       | MIT

- [x] Reply to the question below

The behavior described below is correct?

```yml
emoticonA: #1 from imports
    smilies: [ :a:, :aa:, :a2: ]

emoticonAB:
    smilies: [ :a:, :b: ]

emoticonA: #2
    smilies: [ :a2: ]
```

same as:

```yml
emoticonA: #1 from imports
    smilies: [ :aa: ]

emoticonAB:
    smilies: [ :a:, :b: ]

emoticonA: #2
    smilies: [ :a2: ]
```

Smiley list resulting: `[ :aa:, :a:, :b:, :a2: ]`

Lookup added tests for more details.