### PR TITLE
Fixed class autoloading, using PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,8 @@
         "symfony/symfony": "~2.1"
     },
     "autoload": {
-        "psr-0": { "FM\\BbcodeBundle": "" }
+        "psr-4": { "FM\\BbcodeBundle\\": "" }
     },
-    "target-dir": "FM/BbcodeBundle",
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Related tickets |  |
| License | MIT |

We should use PSR-4 because `target-dir` field is now deprecated on Composer.

From the composer documentation v1.0:

target-dir

> DEPRECATED: This is only present to support legacy PSR-0 style autoloading,
> and all new code should preferably use PSR-4 without target-dir and projects
> using PSR-0 with PHP namespaces are encouraged to migrate to PSR-4 instead.
