### PR TITLE
Removed the `scripts` field on composer config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,13 +39,5 @@
         "branch-alias": {
             "dev-master": "6.x-dev"
         }
-    },
-    "scripts": {
-        "post-install-cmd": [
-            "FM\\BbcodeBundle\\Composer\\ScriptHandler::installEmoticons"
-        ],
-        "post-update-cmd": [
-            "FM\\BbcodeBundle\\Composer\\ScriptHandler::installEmoticons"
-        ]
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Related tickets |  |
| License | MIT |

The `scripts` field is useless on a library package.

From the composer documentation v1.0:

> Note: Only scripts defined in the root package's `composer.json` are
> executed. If a dependency of the root package specifies its own scripts,
> Composer does not execute those additional scripts.
