### PR TITLE
Added support to load emoticons configuration from a php file

### DIFF
--- a/Decoda/Hook/EmoticonHook.php
+++ b/Decoda/Hook/EmoticonHook.php
@@ -9,6 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
 use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Config\Loader\LoaderInterface;
 
 use Decoda\Decoda;
 use \Decoda\Hook\EmoticonHook as BaseEmoticonHook;
@@ -16,7 +17,6 @@ use \Decoda\Hook\EmoticonHook as BaseEmoticonHook;
 use FM\BbcodeBundle\Emoticon\Emoticon;
 use FM\BbcodeBundle\Emoticon\EmoticonCollection;
 use FM\BbcodeBundle\Emoticon\Matcher\MatcherInterface;
-use FM\BbcodeBundle\Emoticon\Loader\FileLoader;
 
 
 /**
@@ -27,7 +27,7 @@ use FM\BbcodeBundle\Emoticon\Loader\FileLoader;
 class EmoticonHook extends BaseEmoticonHook implements CacheWarmerInterface
 {
     /**
-     * @var FileLoader
+     * @var LoaderInterface
      */
     protected $loader;
 
@@ -55,11 +55,11 @@ class EmoticonHook extends BaseEmoticonHook implements CacheWarmerInterface
     /**
      * Constructor.
      *
-     * @param FileLoader $loader   A LoaderInterface instance
+     * @param LoaderInterface $loader   A LoaderInterface instance
      * @param mixed           $resource The main resource to load
      * @param array           $options  An array of options
      */
-    public function __construct(FileLoader $loader, ContainerInterface $container, array $options = array())
+    public function __construct(LoaderInterface $loader, ContainerInterface $container, array $options = array())
     {
         $this->loader = $loader;
         $this->container = $container;

--- a/Emoticon/Loader/PhpFileLoader.php
+++ b/Emoticon/Loader/PhpFileLoader.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace FM\BbcodeBundle\Emoticon\Loader;
+
+use Symfony\Component\Config\Resource\FileResource;
+
+use FM\BbcodeBundle\Emoticon\EmoticonCollection;
+
+
+/**
+ * PhpFileLoader loads PHP files emoticons.
+ *
+ * @author Alexandre Quercia <alquerci@email.com>
+ */
+class PhpFileLoader extends FileLoader
+{
+    /**
+     * Loads the resource and return the result.
+     *
+     * @param mixed  $resource
+     * @param string $type
+     *
+     * @return EmoticonCollection
+     */
+    public function load($resource, $type = null)
+    {
+        $path = $this->locator->locate($resource);
+        $this->setCurrentDir(dirname($path));
+
+        // the loader variable is exposed to the included file below
+        $loader = $this;
+
+        $collection = include $path;
+        $collection->addResource(new FileResource($path));
+
+        return $collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($resource, $type = null)
+    {
+        return is_string($resource) && 'php' === pathinfo($resource, PATHINFO_EXTENSION) && (!$type || 'php' === $type);
+    }
+}

--- a/Resources/config/hooks.xml
+++ b/Resources/config/hooks.xml
@@ -10,7 +10,10 @@
     <parameter key="fm_bbcode.decoda.hook.emoticon.class">FM\BbcodeBundle\Decoda\Hook\EmoticonHook</parameter>
     <parameter key="fm_bbcode.decoda.hook.code.class">Decoda\Hook\CodeHook</parameter>
 
+    <parameter key="fm_bbcode.emoticon.delegating_loader.class">Symfony\Component\Config\Loader\DelegatingLoader</parameter>
+    <parameter key="fm_bbcode.emoticon.loader_resolver.class">Symfony\Component\Config\Loader\LoaderResolver</parameter>
     <parameter key="fm_bbcode.emoticon.loader.yaml.class">FM\BbcodeBundle\Emoticon\Loader\YamlFileLoader</parameter>
+    <parameter key="fm_bbcode.emoticon.loader.php.class">FM\BbcodeBundle\Emoticon\Loader\PhpFileLoader</parameter>
     <parameter key="fm_bbcode.emoticon.options.matcher_class">FM\BbcodeBundle\Emoticon\Matcher\Matcher</parameter>
     <parameter key="fm_bbcode.emoticon.options.matcher_base_class">FM\BbcodeBundle\Emoticon\Matcher\Matcher</parameter>
     <parameter key="fm_bbcode.emoticon.options.matcher_dumper_class">FM\BbcodeBundle\Emoticon\Matcher\Dumper\PhpMatcherDumper</parameter>
@@ -27,7 +30,7 @@
     <service id="fm_bbcode.decoda.hook.emoticon" class="%fm_bbcode.decoda.hook.emoticon.class%">
       <tag name="fm_bbcode.decoda.hook" id="emoticon" />
       <tag name="kernel.cache_warmer" />
-      <argument type="service" id="fm_bbcode.emoticon.loader.yaml" />
+      <argument type="service" id="fm_bbcode.emoticon.loader" />
       <argument type="service" id="service_container" />
       <argument type="collection">
         <argument key="cache_dir">%kernel.cache_dir%</argument>
@@ -42,7 +45,20 @@
       <tag name="fm_bbcode.decoda.hook" id="code" />
     </service>
 
+    <service id="fm_bbcode.emoticon.loader" alias="fm_bbcode.emoticon.delegating_loader" />
+    <service id="fm_bbcode.emoticon.delegating_loader" class="%fm_bbcode.emoticon.delegating_loader.class%">
+      <argument type="service" id="fm_bbcode.emoticon.loader_resolver" />
+    </service>
+    <service id="fm_bbcode.emoticon.loader_resolver" class="%fm_bbcode.emoticon.loader_resolver.class%">
+      <argument type="collection">
+        <argument type="service" id="fm_bbcode.emoticon.loader.yaml" />
+        <argument type="service" id="fm_bbcode.emoticon.loader.php" />
+      </argument>
+    </service>
     <service id="fm_bbcode.emoticon.loader.yaml" class="%fm_bbcode.emoticon.loader.yaml.class%">
+      <argument type="service" id="file_locator"/>
+    </service>
+    <service id="fm_bbcode.emoticon.loader.php" class="%fm_bbcode.emoticon.loader.php.class%">
       <argument type="service" id="file_locator"/>
     </service>
   </services>

--- a/Tests/Emoticon/Loader/PhpFileLoaderTest.php
+++ b/Tests/Emoticon/Loader/PhpFileLoaderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace FM\BbcodeBundle\Tests\Emoticon\Loader;
+
+use Symfony\Component\Config\FileLocator;
+
+use FM\BbcodeBundle\Emoticon\Loader\PhpFileLoader;
+
+/**
+ * @author Alexandre Quercia <alquerci@email.com>
+ */
+class PhpFileLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers FM\BbcodeBundle\Emoticon\Loader\PhpFileLoader::supports
+     */
+    public function testSupports()
+    {
+        $loader = new PhpFileLoader(new FileLocator());
+
+        $this->assertTrue($loader->supports('foo.php'), '->supports() returns true if the resource is loadable');
+        $this->assertFalse($loader->supports('foo.foo'), '->supports() returns true if the resource is loadable');
+    }
+
+    /**
+     * @covers FM\BbcodeBundle\Emoticon\Loader\PhpFileLoader::load
+     */
+    public function testLoad()
+    {
+        $loader = new PhpFileLoader(new FileLocator());
+
+        $collection = $loader->load(__DIR__.'/../../Fixtures/Emoticon/php/simple.php');
+
+        $this->assertInstanceOf('FM\BbcodeBundle\Emoticon\EmoticonCollection', $collection);
+        $this->assertTrue($collection->has('foo'), '->load() loads a PHP file resource');
+        $this->assertCount(1, $collection->getResources());
+    }
+
+    /**
+     * @covers FM\BbcodeBundle\Emoticon\Loader\PhpFileLoader::load
+     */
+    public function testLoadSupportImport()
+    {
+        $loader = new PhpFileLoader(new FileLocator());
+
+        $collection = $loader->load(__DIR__.'/../../Fixtures/Emoticon/php/import.php');
+        $this->assertCount(2, $collection->getResources());
+    }
+}

--- a/Tests/Fixtures/Emoticon/php/import.php
+++ b/Tests/Fixtures/Emoticon/php/import.php
@@ -1,0 +1,3 @@
+<?php
+
+return $loader->import('simple.php');

--- a/Tests/Fixtures/Emoticon/php/simple.php
+++ b/Tests/Fixtures/Emoticon/php/simple.php
@@ -1,0 +1,13 @@
+<?php
+
+use FM\BbcodeBundle\Emoticon\EmoticonCollection;
+use FM\BbcodeBundle\Emoticon\Emoticon;
+
+$collection = new EmoticonCollection();
+
+$emoticon = new Emoticon();
+$emoticon->addSmilies(array(':foo:'));
+
+$collection->add('foo', $emoticon);
+
+return  $collection;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Related tickets |
| License       | MIT

- [x] Added tests for the PhpFileLoader (e.g. [Like from Symfony][0])

The goal is to remove hard code configuration into the [EmoticonHook][1].

[0]: https://github.com/symfony/symfony/blob/2.7/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
[1]: https://github.com/helios-ag/FMBbCodeBundle/blob/6.6/Decoda/Hook/EmoticonHook.php#L163