### PR TITLE
Added default emoticons configuration loaded from Decoda

### DIFF
--- a/Resources/config/emoticons.php
+++ b/Resources/config/emoticons.php
@@ -1,0 +1,26 @@
+<?php
+
+use Decoda\Decoda;
+use Decoda\Hook\EmoticonHook;
+
+use FM\BbcodeBundle\Emoticon\EmoticonCollection;
+use FM\BbcodeBundle\Emoticon\Emoticon;
+
+// Convert a default decoda emoticons array to an EmoticonCollection
+$collection = new EmoticonCollection();
+
+$decoda = new Decoda();
+$hook = new EmoticonHook();
+$hook->setParser($decoda);
+$hook->startup();
+$emoticons = $hook->getEmoticons();
+
+foreach ($emoticons as $name => $smilies) {
+    $emoticon = new Emoticon();
+    foreach ($smilies as $smiley) {
+        $emoticon->setSmiley($smiley);
+    }
+    $collection->add($name, $emoticon);
+}
+
+return  $collection;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Related tickets | #97
| License       | MIT

It will be useful to load emoticons from Decoda through a configuration.